### PR TITLE
feat(LaunchDarkly): add check for current flags changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ test-types.js
 docs/build/
 yarn.lock
 package-lock.json
-.npmrc

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+@joor:registry=https://npm.pkg.github.com/joor
+//npm.pkg.github.com/:_authToken=${NPM_TOKEN}
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "launchdarkly-react-client-sdk",
-  "version": "3.0.10",
-  "description": "LaunchDarkly SDK for React",
+  "name": "@joor/launchdarkly-react-client-sdk",
+  "version": "3.0.10-1",
+  "description": "Joor's fork of LaunchDarkly SDK for React",
   "author": "LaunchDarkly <team@launchdarkly.com>",
   "license": "Apache-2.0",
   "keywords": [
@@ -42,9 +42,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/launchdarkly/react-client-sdk.git"
+    "url": "git://github.com/joor/react-client-sdk.git"
   },
-  "homepage": "https://github.com/launchdarkly/react-client-sdk",
+  "homepage": "https://github.com/joor/react-client-sdk",
   "devDependencies": {
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-node-resolve": "^15.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joor/launchdarkly-react-client-sdk",
-  "version": "3.0.10-1",
+  "version": "3.0.10-2",
   "description": "Joor's fork of LaunchDarkly SDK for React",
   "author": "LaunchDarkly <team@launchdarkly.com>",
   "license": "Apache-2.0",

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -62,7 +62,9 @@ class LDProvider extends Component<PropsWithChildren<ProviderConfig>, LDHocState
     const { flags: targetFlags } = this.props;
     ldClient.on('change', (changes: LDFlagChangeset) => {
       const reactOptions = this.getReactOptions();
-      const updates = getFlattenedFlagsFromChangeset(changes, targetFlags);
+      // Add this.state.unproxiedFlags as a new attribute for getFlattenedFlagsFromChangeset so
+      // the method now can validate if the FF changed or remained the same
+      const updates = getFlattenedFlagsFromChangeset(changes, targetFlags, this.state.unproxiedFlags);
       const unproxiedFlags = {
         ...this.state.unproxiedFlags,
         ...updates,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,16 +33,22 @@ export const camelCaseKeys = (rawFlags: LDFlagSet) => {
  * @param changes the `LDFlagChangeset` from the ldClient onchange handler.
  * @param targetFlags if targetFlags are specified, changes to other flags are ignored and not returned in the
  * flattened `LDFlagSet`
+ * @param currentFlags if currentFlags are specified, changes to those specific flags will be taken into account,
+ * the rest will be ignored
  * @return an `LDFlagSet` with the current flag values from the LDFlagChangeset filtered by `targetFlags`. The returned
  * object may be empty `{}` if none of the targetFlags were changed.
  */
 export const getFlattenedFlagsFromChangeset = (
   changes: LDFlagChangeset,
   targetFlags: LDFlagSet | undefined,
+  currentFlags?: LDFlagSet | undefined,
 ): LDFlagSet => {
   const flattened: LDFlagSet = {};
   for (const key in changes) {
-    if (!targetFlags || targetFlags[key] !== undefined) {
+    if (
+      (!targetFlags || targetFlags[key] !== undefined) &&
+      (!currentFlags || currentFlags[key] !== changes[key].current)
+    ) {
       flattened[key] = changes[key].current;
     }
   }


### PR DESCRIPTION
## What changed and why?

This current version of the LaunchDarkly SDK is executing an update every time a flag changed in the environment, even if the changes didn't affect the user, this it's making a re-render effect over the user every time we updated a flag in LaunchDarkly.

This PR adds a validation for checking when current flags have a change and only then execute a setState, if there is no changes with the current flags, we shouldn't call setState.
